### PR TITLE
handle anonymous default exports

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -55,6 +55,27 @@ function importDecl(str: string, start: number, end: number, specifiers: Specifi
 function exportDefaultDeclaration(str: string, start: number, end: number) {
 	while (/\S/.test(str[end])) end += 1;
 
+	const match = /^\s*(?:(class)\s*{|(function)\s*\()/.exec(str.slice(end));
+
+	if (match) {
+		// anonymous class declaration
+		end += match[0].length;
+
+		const name = '__default_export';
+
+		return {
+			start,
+			end,
+			name,
+			as: 'default',
+			toString() {
+				return match[1]
+					? `class ${name}{`
+					: `function ${name}(`;
+			}
+		};
+	}
+
 	return {
 		start,
 		end,
@@ -623,7 +644,7 @@ export function transform(source: string, id: string) {
 	transformed += source.slice(c);
 
 	exportDeclarations.forEach(d => {
-		if (d.name) transformed += `\n__exports.${d.name} = ${d.name};`;
+		if (d.name) transformed += `\n__exports.${d.as || d.name} = ${d.name};`;
 	});
 
 	transformed += `\n});\n//# sourceURL=${id}`;

--- a/test/samples/export-default-unnamed-class/actual.js
+++ b/test/samples/export-default-unnamed-class/actual.js
@@ -1,0 +1,4 @@
+__shimport__.define('./export-default-unnamed-class/input.js', [], function(__import, __exports){ class __default_export{}foo=42
+__exports.default = __default_export;
+});
+//# sourceURL=./export-default-unnamed-class/input.js

--- a/test/samples/export-default-unnamed-class/input.js
+++ b/test/samples/export-default-unnamed-class/input.js
@@ -1,0 +1,1 @@
+export default class{}foo=42

--- a/test/samples/export-default-unnamed-class/output.js
+++ b/test/samples/export-default-unnamed-class/output.js
@@ -1,0 +1,4 @@
+__shimport__.define('./export-default-unnamed-class/input.js', [], function(__import, __exports){ class __default_export{}foo=42
+__exports.default = __default_export;
+});
+//# sourceURL=./export-default-unnamed-class/input.js

--- a/test/samples/export-default-unnamed-function/actual.js
+++ b/test/samples/export-default-unnamed-function/actual.js
@@ -1,0 +1,4 @@
+__shimport__.define('./export-default-unnamed-function/input.js', [], function(__import, __exports){ function __default_export(){}foo=42
+__exports.default = __default_export;
+});
+//# sourceURL=./export-default-unnamed-function/input.js

--- a/test/samples/export-default-unnamed-function/input.js
+++ b/test/samples/export-default-unnamed-function/input.js
@@ -1,0 +1,1 @@
+export default function(){}foo=42

--- a/test/samples/export-default-unnamed-function/output.js
+++ b/test/samples/export-default-unnamed-function/output.js
@@ -1,0 +1,4 @@
+__shimport__.define('./export-default-unnamed-function/input.js', [], function(__import, __exports){ function __default_export(){}foo=42
+__exports.default = __default_export;
+});
+//# sourceURL=./export-default-unnamed-function/input.js

--- a/test/test.ts
+++ b/test/test.ts
@@ -8,10 +8,10 @@ describe('shimport', () => {
 
 		it(dir, () => {
 			const input = fs.readFileSync(`test/samples/${dir}/input.js`, 'utf-8');
-			const expected = fs.readFileSync(`test/samples/${dir}/output.js`, 'utf-8');
-
 			const actual = shimport.transform(input, `./${dir}/input.js`);
 			fs.writeFileSync(`test/samples/${dir}/actual.js`, actual);
+
+			const expected = fs.readFileSync(`test/samples/${dir}/output.js`, 'utf-8');
 
 			assert.equal(actual, expected);
 		});


### PR DESCRIPTION
fixes #13. Figuring out where to place a semicolon is prohibitively difficult, so this just gives the anonymous class/function a name and exports it at the end