### PR TITLE
correctly transform `export default` followed by non-whitespace

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -53,8 +53,6 @@ function importDecl(str: string, start: number, end: number, specifiers: Specifi
 }
 
 function exportDefaultDeclaration(str: string, start: number, end: number) {
-	while (/\S/.test(str[end])) end += 1;
-
 	const match = /^\s*(?:(class)(\s+extends|\s*{)|(function)\s*\()/.exec(str.slice(end));
 
 	if (match) {
@@ -279,11 +277,11 @@ function getExportDeclaration(str: string, i: number) {
 		);
 	}
 
-	if (/default[\s\n]/.test(str.slice(i, i + 8))) {
+	if (/^default\b/.test(str.slice(i, i + 8))) {
 		return exportDefaultDeclaration(
 			str,
 			start,
-			declarationStart
+			declarationStart + 7
 		);
 	}
 

--- a/test/samples/export-default-no-space/actual.js
+++ b/test/samples/export-default-no-space/actual.js
@@ -1,0 +1,3 @@
+__shimport__.define('./export-default-no-space/input.js', [], function(__import, __exports){ __exports.default =[42];
+});
+//# sourceURL=./export-default-no-space/input.js

--- a/test/samples/export-default-no-space/input.js
+++ b/test/samples/export-default-no-space/input.js
@@ -1,0 +1,1 @@
+export default[42];

--- a/test/samples/export-default-no-space/output.js
+++ b/test/samples/export-default-no-space/output.js
@@ -1,0 +1,3 @@
+__shimport__.define('./export-default-no-space/input.js', [], function(__import, __exports){ __exports.default =[42];
+});
+//# sourceURL=./export-default-no-space/input.js


### PR DESCRIPTION
Fixes #22. I _think_ this is safe. It doesn't break any other tests.

Just changing the regex to `/^default\b/` didn't work, because `exportDefaultDeclaration` was still looking for whitespace after `end`. (And it would hang if it never found any.) However, I'm pretty sure the characters the while loop skips over are always going to be precisely `default`. So I removed that loop, and am now simply passing `declarationStart + 7` as the third argument.