### PR TITLE
IE11 compatibility

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -229,7 +229,7 @@ function getImportMetaUrl(str: string, start: number, id: string) {
 			start,
 			end: start + match[0].length,
 			toString() {
-				return JSON.stringify(id);
+				return JSON.stringify('' + id);
 			}
 		}
 	}


### PR DESCRIPTION
Without this I was getting the errors below when trying to use Shimport with Sapper's `inject_styles`

![Screenshot from 2020-09-17 20-00-35](https://user-images.githubusercontent.com/322311/93555457-d83c6200-f92a-11ea-88f9-ff340aa4a61c.png)
