### PR TITLE
Reverts sucrase back to typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,14 +46,14 @@
         "magic-string": "^0.25.5"
       }
     },
-    "@rollup/plugin-sucrase": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-sucrase/-/plugin-sucrase-3.1.0.tgz",
-      "integrity": "sha512-PZ70LDNgIj8rL+3pKwKwTBOQ2c9JofXeLbWz+2V4/nCt4LqwYTNqxJJf1riTJsVARVzJdA0woIzUzjKZvL8TfA==",
+    "@rollup/plugin-typescript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-6.0.0.tgz",
+      "integrity": "sha512-Y5U2L4eaF3wUSgCZRMdvNmuzWkKMyN3OwvhAdbzAi5sUqedaBk/XbzO4T7RlViDJ78MOPhwAIv2FtId/jhMtbg==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.1",
-        "sucrase": "^3.10.1"
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
       }
     },
     "@rollup/pluginutils": {
@@ -1166,6 +1166,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1293,6 +1299,15 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
       }
     },
     "restore-cursor": {
@@ -1731,6 +1746,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-replace": "^2.3.3",
-    "@rollup/plugin-sucrase": "^3.1.0",
+    "@rollup/plugin-typescript": "^6.0.0",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
     "kleur": "^4.1.1",
@@ -21,6 +21,7 @@
     "sirv-cli": "^1.0.6",
     "sucrase": "^3.15.0",
     "surge": "^0.21.6",
+    "typescript": "^4.0.3",
     "uvu": "^0.3.3"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import sucrase from '@rollup/plugin-sucrase';
+import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
@@ -13,9 +13,11 @@ const config = dev => ({
 		}
 	],
 	plugins: [
-		sucrase({ transforms: ['typescript'] }),
 		replace({
 			__VERSION__: pkg.version
+		}),
+		typescript({
+			typescript: require('typescript')
 		}),
 		!dev && terser()
 	]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,11 @@ const config = dev => ({
 		typescript({
 			typescript: require('typescript')
 		}),
-		!dev && terser()
+		!dev && terser({
+			output: {
+				comments: false
+			}
+		})
 	]
 })
 


### PR DESCRIPTION
Fixes https://github.com/Rich-Harris/shimport/issues/34 which essentially undoes the commit at https://github.com/Rich-Harris/shimport/commit/2954ed097b066371c11a999ded9f70395ec80dea which converted to Sucrase from Typescript.

The given reasons for the upgrade were unknown but probably relate to compilation speed. Whilst this is certainly slower to compile now, it's a difference of 2.5 seconds in total, so negligable.

The reason for the move from Sucrase to Typescript is for legacy browser support, which isn't supported by sucrase at all.