### PR TITLE
Fixes named exports containing '$' character

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -138,8 +138,9 @@ function isQuote(char: string) {
 	return char === "'" || char === '"';
 }
 
-const namespaceImport = /^\*\s+as\s+(\w+)$/;
-const defaultAndStarImport = /(\w+)\s*,\s*\*\s*as\s*(\w+)$/;
+const 
+Import = /^\*\s+as\s+(\S+)$/;
+const defaultAndStarImport = /(\w+)\s*,\s*\*\s*as\s*(\S+)$/;
 const defaultAndNamedImport = /(\w+)\s*,\s*{(.+)}$/;
 
 function processImportSpecifiers(str: string): Specifier[] {


### PR DESCRIPTION
Some bundlers (for example Rollup) use $ character in name exports. 

`import * as format$1 from './format.mjs'`

This fixes it

